### PR TITLE
Check setLocation results in Timezones example

### DIFF
--- a/ezTime/examples/Timezones/Timezones.ino
+++ b/ezTime/examples/Timezones/Timezones.ino
@@ -19,18 +19,24 @@ void setup() {
 
 	// Provide official timezone names
 	// https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-	myTZ.setLocation(F("Pacific/Auckland"));
-	Serial.print(F("New Zealand:     "));
-	Serial.println(myTZ.dateTime());
+        if (myTZ.setLocation(F("Pacific/Auckland"))) {
+                Serial.print(F("New Zealand:     "));
+                Serial.println(myTZ.dateTime());
+        } else {
+                Serial.println(errorString());
+        }
 
 	// Wait a little bit to not trigger DDoS protection on server
 	// See https://github.com/ropg/ezTime#timezonedropnl
 	delay(5000);
 
 	// Or country codes for countries that do not span multiple timezones
-	myTZ.setLocation(F("de"));
-	Serial.print(F("Germany:         "));
-	Serial.println(myTZ.dateTime());
+        if (myTZ.setLocation(F("de"))) {
+                Serial.print(F("Germany:         "));
+                Serial.println(myTZ.dateTime());
+        } else {
+                Serial.println(errorString());
+        }
 
 	// Same as above
 	delay(5000);


### PR DESCRIPTION
## Summary
- add checks after `setLocation` calls in Timezones example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b64673f1c8324add9e43c2fb3fdcf