### PR TITLE
Fix README constant

### DIFF
--- a/ezTime/README.md
+++ b/ezTime/README.md
@@ -543,7 +543,7 @@ if (weekday() == TUESDAY) Serial.print("Tuesday!!");
 ```
 
 ```
-if (month() == FEBRUARY && day() == 14) Serial.print("Valentine's day!");
+if (month() == FEBRUARI && day() == 14) Serial.print("Valentine's day!");
 ```
 
 &nbsp;

--- a/ezTime/README.txt
+++ b/ezTime/README.txt
@@ -543,7 +543,7 @@ if (weekday() == TUESDAY) Serial.print("Tuesday!!");
 ```
 
 ```
-if (month() == FEBRUARY && day() == 14) Serial.print("Valentine's day!");
+if (month() == FEBRUARI && day() == 14) Serial.print("Valentine's day!");
 ```
 
 &nbsp;


### PR DESCRIPTION
## Summary
- update the examples in README files to use `FEBRUARI` instead of the incorrect `FEBRUARY`

## Testing
- `grep -n "FEBRUARI" -n ezTime/README.md`


------
https://chatgpt.com/codex/tasks/task_e_687b645dffe08324a925ffa4354b097e